### PR TITLE
fix python-bcb silver modelling

### DIFF
--- a/dbt_macro_modelling/models/silver/variacao_indices.sql
+++ b/dbt_macro_modelling/models/silver/variacao_indices.sql
@@ -10,7 +10,8 @@ WITH cdi_v AS (
         cod_sgs::text as ticker,
         upper(nm_indice) as tickernome,
         valor as fechamento,
-        COALESCE(valor / NULLIF(LAG(valor) OVER (PARTITION BY cod_sgs ORDER BY data), 0) - 1, 0) AS variacao_diaria
+        -- COALESCE(valor / NULLIF(LAG(valor) OVER (PARTITION BY cod_sgs ORDER BY data), 0) - 1, 0) AS variacao_diaria
+        valor AS variacao_diaria  -- python-bcb indexes actually are already daily/monthly vars. 
     FROM raw.cdi
     {% if is_incremental() %}
         WHERE data > (SELECT max(dataCotacao) FROM {{ this }})
@@ -24,7 +25,8 @@ ipca_v AS (
         cod_sgs::text as ticker,
         upper(nm_indice) as tickernome,
         valor as fechamento,
-        COALESCE(valor / NULLIF(LAG(valor) OVER (PARTITION BY cod_sgs ORDER BY data), 0) - 1, 0) AS variacao_diaria
+        -- COALESCE(valor / NULLIF(LAG(valor) OVER (PARTITION BY cod_sgs ORDER BY data), 0) - 1, 0) AS variacao_diaria
+        valor AS variacao_diaria  -- python-bcb indexes actually are already daily/monthly vars. 
     FROM raw.ipca
     {% if is_incremental() %}
         WHERE data > (SELECT max(dataCotacao) FROM {{ this }})
@@ -38,7 +40,8 @@ igpm_v AS (
         cod_sgs::text as ticker,
         upper(nm_indice) as tickernome,
         valor as fechamento,
-        COALESCE(valor / NULLIF(LAG(valor) OVER (PARTITION BY cod_sgs ORDER BY data), 0) - 1, 0) AS variacao_diaria
+        -- COALESCE(valor / NULLIF(LAG(valor) OVER (PARTITION BY cod_sgs ORDER BY data), 0) - 1, 0) AS variacao_diaria
+        valor AS variacao_diaria  -- python-bcb indexes actually are already daily/monthly vars. 
     FROM raw.igpm
     {% if is_incremental() %}
         WHERE data > (SELECT max(dataCotacao) FROM {{ this }})

--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ class Main:
             .option("dbtable", f"{schema}.{table_name}") \
             .option("user", self.connector.user) \
             .option("password", self.connector.password) \
+            .option("driver", "org.postgresql.Driver") \
             .mode(mode) \
             .save()
 


### PR DESCRIPTION
-> brazillian indexes actually are returned as variation percentages theres no need to calculate the var between the time series in these cases